### PR TITLE
Delete provider so an outside provider can be used

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  region  = var.aws_region
-  profile = var.aws_profile
-}

--- a/variables.tf
+++ b/variables.tf
@@ -20,13 +20,3 @@ variable "shiftright_external_id" {
   type        = string
   description = "External Id that will be used in request to assume role"
 }
-
-variable "aws_region" {
-  type        = string
-  description = "AWS region"
-}
-
-variable "aws_profile" {
-  type        = string
-  description = "AWS account profile"
-}


### PR DESCRIPTION
It would be better to use this module as a module and allow explicit usage of a provider from outside of the module.

By removing the provider from inside the module, we can explicitly set the provider like this.

```hcl
provider "aws" {
  alias  = "usw2"
  region = "us-west-2"
}

module "shift_right" {
  source = "git@github.com:shiftright-org/terraform-aws-cross-account-role.git"

  # ... required inputs to the module

  providers = {
    aws = aws.usw2
  }
}
```

See https://www.terraform.io/docs/language/modules/develop/providers.html#passing-providers-explicitly